### PR TITLE
Use BaseLoader to avoid type mapping

### DIFF
--- a/meta_yaml.py
+++ b/meta_yaml.py
@@ -53,9 +53,9 @@ from markdown import Extension
 from markdown.preprocessors import Preprocessor
 import yaml
 try:
-    from yaml import CSafeLoader as Loader
+    from yaml import CBaseLoader as Loader
 except ImportError:
-    from yaml import Loader
+    from yaml import BaseLoader
 
 
 # Override the default string handling function to always return unicode objects


### PR DESCRIPTION
In PyYAML tag types are mapped to python types (http://pyyaml.org/wiki/PyYAMLDocumentation#YAMLtagsandPythontypes)

In contrast, in Markdown Meta-Data extension, values are strings (https://pythonhosted.org/Markdown/extensions/meta_data.html).

The BaseLoader class only construct basic Python objects: lists, dictionaries and Unicode strings so will likely perform more as expected.