### PR TITLE
Fix BaseLoader import

### DIFF
--- a/meta_yaml.py
+++ b/meta_yaml.py
@@ -55,7 +55,7 @@ import yaml
 try:
     from yaml import CBaseLoader as Loader
 except ImportError:
-    from yaml import BaseLoader
+    from yaml import BaseLoader as Loader
 
 
 # Override the default string handling function to always return unicode objects


### PR DESCRIPTION
Fixes an exception when not using the C extension:

```
NameError: name 'Loader' is not defined
```
